### PR TITLE
feat(ntfy): private ntfy for the addon release flow

### DIFF
--- a/.github/workflows/ntfy.yaml
+++ b/.github/workflows/ntfy.yaml
@@ -36,8 +36,8 @@ jobs:
             --namespace default \
             -f values.yaml \
             --set ingress.host="ntfy.${{ vars.HOST }}" \
-            --set-string auth.publishHash="$NTFY_PUBLISH_HASH" \
-            --set-string auth.readHash="$NTFY_READ_HASH"
+            --set-string auth.passwordHashes.ha="$NTFY_PUBLISH_HASH" \
+            --set-string auth.passwordHashes.ci="$NTFY_READ_HASH"
         working-directory: kubernetes/charts/ntfy
 
       - name: Disconnect from Kubernetes

--- a/.github/workflows/ntfy.yaml
+++ b/.github/workflows/ntfy.yaml
@@ -28,16 +28,16 @@ jobs:
       - name: Install ntfy
         # Passed via env (not inline --set) so the bcrypt '$' chars aren't shell-expanded.
         env:
-          NTFY_PUBLISH_HASH: ${{ secrets.NTFY_PUBLISH_HASH }}
-          NTFY_READ_HASH: ${{ secrets.NTFY_READ_HASH }}
+          HA_HASH: ${{ secrets.NTFY_HA_HASH }}
+          CI_HASH: ${{ secrets.NTFY_CI_HASH }}
         run: |
           helm upgrade --install --wait --atomic --debug \
             ntfy . \
             --namespace default \
             -f values.yaml \
             --set ingress.host="ntfy.${{ vars.HOST }}" \
-            --set-string auth.passwordHashes.ha="$NTFY_PUBLISH_HASH" \
-            --set-string auth.passwordHashes.ci="$NTFY_READ_HASH"
+            --set-string auth.passwordHashes.ha="$HA_HASH" \
+            --set-string auth.passwordHashes.ci="$CI_HASH"
         working-directory: kubernetes/charts/ntfy
 
       - name: Disconnect from Kubernetes

--- a/.github/workflows/ntfy.yaml
+++ b/.github/workflows/ntfy.yaml
@@ -1,0 +1,45 @@
+name: ntfy
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  push:
+    branches: [main]
+    paths:
+      - 'kubernetes/charts/ntfy/**'
+      - '.github/workflows/ntfy.yaml'
+
+jobs:
+  deploy-ntfy:
+    name: Deploy ntfy
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Connect to Kubernetes
+        uses: ./.github/actions/connect-k8s
+        with:
+          kubeconfig: "${{ secrets.KUBECONFIG }}"
+          hostname: kubernetes-api.${{ vars.HOST }}
+          serviceTokenId: ${{ vars.CLOUDFLARE_TUNNEL_SERVICE_TOKEN_ID }}
+          serviceTokenSecret: ${{ secrets.CLOUDFLARE_TUNNEL_SERVICE_TOKEN_SECRET }}
+
+      - name: Install ntfy
+        # Passed via env (not inline --set) so the bcrypt '$' chars aren't shell-expanded.
+        env:
+          NTFY_PUBLISH_HASH: ${{ secrets.NTFY_PUBLISH_HASH }}
+          NTFY_READ_HASH: ${{ secrets.NTFY_READ_HASH }}
+        run: |
+          helm upgrade --install --wait --atomic --debug \
+            ntfy . \
+            --namespace default \
+            -f values.yaml \
+            --set ingress.host="ntfy.${{ vars.HOST }}" \
+            --set-string auth.publishHash="$NTFY_PUBLISH_HASH" \
+            --set-string auth.readHash="$NTFY_READ_HASH"
+        working-directory: kubernetes/charts/ntfy
+
+      - name: Disconnect from Kubernetes
+        if: always()
+        uses: ./.github/actions/disconnect-k8s

--- a/kubernetes/charts/ntfy/Chart.yaml
+++ b/kubernetes/charts/ntfy/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: ntfy
+type: application
+version: 1.0.0

--- a/kubernetes/charts/ntfy/templates/_helpers.tpl
+++ b/kubernetes/charts/ntfy/templates/_helpers.tpl
@@ -1,0 +1,40 @@
+{{/*
+Build NTFY_AUTH_USERS: "name:hash:role,..." from .Values.auth.users, pulling
+each user's bcrypt hash from .Values.auth.passwordHashes (keyed by name).
+*/}}
+{{- define "ntfy.authUsers" -}}
+{{- $hashes := .Values.auth.passwordHashes | default dict -}}
+{{- $out := list -}}
+{{- range .Values.auth.users -}}
+{{- $hash := required (printf "auth.passwordHashes.%s is required" .name) (index $hashes .name) -}}
+{{- $out = append $out (printf "%s:%s:%s" .name $hash (.role | default "user")) -}}
+{{- end -}}
+{{- join "," $out -}}
+{{- end -}}
+
+{{/*
+Build NTFY_AUTH_ACCESS: "user:topic:permission,..." from each user's access list.
+*/}}
+{{- define "ntfy.authAccess" -}}
+{{- $out := list -}}
+{{- range .Values.auth.users -}}
+{{- $user := .name -}}
+{{- range (.access | default list) -}}
+{{- $out = append $out (printf "%s:%s:%s" $user .topic .permission) -}}
+{{- end -}}
+{{- end -}}
+{{- join "," $out -}}
+{{- end -}}
+
+{{/*
+Build NTFY_AUTH_TOKENS: "user:token[:label],..." from .Values.auth.tokens.
+*/}}
+{{- define "ntfy.authTokens" -}}
+{{- $out := list -}}
+{{- range .Values.auth.tokens -}}
+{{- $entry := printf "%s:%s" .user .token -}}
+{{- with .label }}{{- $entry = printf "%s:%s" $entry . -}}{{- end -}}
+{{- $out = append $out $entry -}}
+{{- end -}}
+{{- join "," $out -}}
+{{- end -}}

--- a/kubernetes/charts/ntfy/templates/deployment.yaml
+++ b/kubernetes/charts/ntfy/templates/deployment.yaml
@@ -32,14 +32,22 @@ spec:
           value: /var/lib/ntfy/user.db
         - name: NTFY_CACHE_FILE
           value: /var/cache/ntfy/cache.db
+        {{- with .Values.auth.defaultAccess }}
         - name: NTFY_AUTH_DEFAULT_ACCESS
-          value: deny-all
+          value: {{ . | quote }}
+        {{- end }}
+        {{- if .Values.auth.users }}
         # Users and access are reconciled from config into the auth db on every
         # start, so the emptyDirs below can be wiped without losing them.
         - name: NTFY_AUTH_USERS
-          value: {{ printf "ha:%s:user,ci:%s:user" (required "auth.publishHash is required" .Values.auth.publishHash) (required "auth.readHash is required" .Values.auth.readHash) | quote }}
+          value: {{ include "ntfy.authUsers" . | quote }}
         - name: NTFY_AUTH_ACCESS
-          value: {{ printf "ha:%s:wo,ci:%s:ro" (required "topic is required" .Values.topic) .Values.topic | quote }}
+          value: {{ include "ntfy.authAccess" . | quote }}
+        {{- end }}
+        {{- if .Values.auth.tokens }}
+        - name: NTFY_AUTH_TOKENS
+          value: {{ include "ntfy.authTokens" . | quote }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /v1/health

--- a/kubernetes/charts/ntfy/templates/deployment.yaml
+++ b/kubernetes/charts/ntfy/templates/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ntfy
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: ntfy
+  template:
+    metadata:
+      labels:
+        app: ntfy
+    spec:
+      containers:
+      - name: ntfy
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        args: ["serve"]
+        ports:
+        - containerPort: 80
+          protocol: TCP
+        env:
+        - name: NTFY_BASE_URL
+          value: {{ printf "https://%s" (required "ingress.host is required" .Values.ingress.host) | quote }}
+        - name: NTFY_LISTEN_HTTP
+          value: ":80"
+        - name: NTFY_BEHIND_PROXY
+          value: "true"
+        - name: NTFY_AUTH_FILE
+          value: /var/lib/ntfy/user.db
+        - name: NTFY_CACHE_FILE
+          value: /var/cache/ntfy/cache.db
+        - name: NTFY_AUTH_DEFAULT_ACCESS
+          value: deny-all
+        # Users and access are reconciled from config into the auth db on every
+        # start, so the emptyDirs below can be wiped without losing them.
+        - name: NTFY_AUTH_USERS
+          value: {{ printf "ha:%s:user,ci:%s:user" (required "auth.publishHash is required" .Values.auth.publishHash) (required "auth.readHash is required" .Values.auth.readHash) | quote }}
+        - name: NTFY_AUTH_ACCESS
+          value: {{ printf "ha:%s:wo,ci:%s:ro" (required "topic is required" .Values.topic) .Values.topic | quote }}
+        livenessProbe:
+          httpGet:
+            path: /v1/health
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 15
+          timeoutSeconds: 3
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /v1/health
+            port: 80
+          initialDelaySeconds: 2
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
+        volumeMounts:
+        - name: lib
+          mountPath: /var/lib/ntfy
+        - name: cache
+          mountPath: /var/cache/ntfy
+      volumes:
+      - name: lib
+        emptyDir: {}
+      - name: cache
+        emptyDir: {}

--- a/kubernetes/charts/ntfy/templates/ingress.yaml
+++ b/kubernetes/charts/ntfy/templates/ingress.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ntfy
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    # The release workflow holds a subscription open while it waits for the code,
+    # so allow long-lived reads and stream messages through without buffering.
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-buffering: "off"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - {{ required "ingress.host is required" .Values.ingress.host | quote }}
+      secretName: ntfy-tls
+  rules:
+  - host: {{ required "ingress.host is required" .Values.ingress.host | quote }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: ntfy
+            port:
+              number: 80

--- a/kubernetes/charts/ntfy/templates/service.yaml
+++ b/kubernetes/charts/ntfy/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ntfy
+spec:
+  selector:
+    app: ntfy
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 80

--- a/kubernetes/charts/ntfy/values.ci.yaml
+++ b/kubernetes/charts/ntfy/values.ci.yaml
@@ -1,5 +1,6 @@
 ingress:
   host: "ntfy.example.com"
 auth:
-  publishHash: "$2a$10$dummydummydummydummyOdummydummydummydummydummydummyd."
-  readHash: "$2a$10$dummydummydummydummyOdummydummydummydummydummydummyd."
+  passwordHashes:
+    ha: "$2a$10$dummydummydummydummyOdummydummydummydummydummydummyd."
+    ci: "$2a$10$dummydummydummydummyOdummydummydummydummydummydummyd."

--- a/kubernetes/charts/ntfy/values.ci.yaml
+++ b/kubernetes/charts/ntfy/values.ci.yaml
@@ -1,0 +1,5 @@
+ingress:
+  host: "ntfy.example.com"
+auth:
+  publishHash: "$2a$10$dummydummydummydummyOdummydummydummydummydummydummyd."
+  readHash: "$2a$10$dummydummydummydummyOdummydummydummydummydummydummyd."

--- a/kubernetes/charts/ntfy/values.yaml
+++ b/kubernetes/charts/ntfy/values.yaml
@@ -2,11 +2,23 @@ image:
   repository: binwiederhier/ntfy
   tag: v2.26.0@sha256:a6d335064ae927c4dbef118e1fa39656b3d2e01472b2a82af5915d5cebfe815f
 ingress: {}
-# Single topic used by the addon release flow. Home Assistant (user "ha") may
-# publish to it; the release workflow (user "ci") may read it. Everything else
-# is denied (auth-default-access: deny-all).
-topic: steam-release
 auth:
-  # bcrypt hashes from `ntfy user hash` - set in pipeline.
-  publishHash: "" # user "ha", write-only (HA publishes the Steam Guard code)
-  readHash: "" # user "ci", read-only (the release workflow subscribes)
+  # Global fallback when no ACL entry matches: read-write | read-only | write-only | deny-all
+  defaultAccess: deny-all
+  # Users and their per-topic access (topics may use a "*" wildcard;
+  # permission: read-write | read-only | write-only | deny). Empty users => a
+  # public instance governed solely by defaultAccess.
+  users:
+    - name: ha
+      role: user # user | admin (admin = read-write to all topics)
+      access:
+        - { topic: steam-release, permission: write-only }
+    - name: ci
+      role: user
+      access:
+        - { topic: steam-release, permission: read-only }
+  # bcrypt hashes keyed by user name, injected by the pipeline so they stay out
+  # of git: { ha: "$2a$...", ci: "$2a$..." }
+  passwordHashes: {}
+  # Optional API tokens for Bearer-auth clients: - { user: ci, token: "tk_...", label: "..." }
+  tokens: []

--- a/kubernetes/charts/ntfy/values.yaml
+++ b/kubernetes/charts/ntfy/values.yaml
@@ -1,0 +1,12 @@
+image:
+  repository: binwiederhier/ntfy
+  tag: v2.26.0@sha256:a6d335064ae927c4dbef118e1fa39656b3d2e01472b2a82af5915d5cebfe815f
+ingress: {}
+# Single topic used by the addon release flow. Home Assistant (user "ha") may
+# publish to it; the release workflow (user "ci") may read it. Everything else
+# is denied (auth-default-access: deny-all).
+topic: steam-release
+auth:
+  # bcrypt hashes from `ntfy user hash` - set in pipeline.
+  publishHash: "" # user "ha", write-only (HA publishes the Steam Guard code)
+  readHash: "" # user "ci", read-only (the release workflow subscribes)

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -8,6 +8,7 @@ locals {
     "send",
     "ts",
     "convert",
+    "ntfy",
     "pdf",
     "minecraft-forge",
     "minecraft-vanilla",


### PR DESCRIPTION
## What

Adds a private, generic **ntfy** deployment (`kubernetes/charts/ntfy` + `.github/workflows/ntfy.yaml`) plus its DNS record, exposed at `ntfy.<HOST>`.

It's the relay for the automated GMod addon **Workshop release flow**: Home Assistant publishes the Steam Guard code to a topic, and the addon release workflow subscribes and waits for it — so no Steam credential or HA token ever has to live in the public addon repos.

## Design

- **Private:** `auth-default-access: deny-all`, with users/access provisioned **declaratively** (`auth-users`/`auth-access`, reconciled into the auth db on boot — so no seeding job and no PVC).
- **Generic:** the chart takes an arbitrary `auth.users` list (name / role / per-topic access), a `defaultAccess`, and optional API `tokens` — folded into `NTFY_AUTH_USERS`/`ACCESS`/`TOKENS`. bcrypt hashes are injected per-user by name (`auth.passwordHashes.<name>`) so they stay out of git. Empty `users` ⇒ a public instance. Reusable for other topics/notifications, not just the release flow.
- Default config ships two users on topic `steam-release`: `ha` (write-only, HA publishes) and `ci` (read-only, the release workflow subscribes).
- **Ingress:** nginx + `letsencrypt-prod`, with `proxy-read-timeout: 600` and `proxy-buffering: off` so the held-open subscription streams through.
- **DNS:** `ntfy` added to `terraform/dns.tf` (CNAME to the cluster, same as the other apps).
- Image digest-pinned (`binwiederhier/ntfy:v2.26.0@sha256:…`), Renovate-friendly.

Validated locally: `helm lint`, `helm template`, and `kubeconform --strict` (k8s 1.31.0) all pass.

## Required before merge (deploy runs on merge to `main`)

**Repo secrets** (Settings → Secrets and variables → Actions):
- `NTFY_HA_HASH` — bcrypt hash of the `ha` user's password
- `NTFY_CI_HASH` — bcrypt hash of the `ci` user's password

Generate each with:
```
docker run --rm -it binwiederhier/ntfy:v2.26.0 user hash
```
(Reuses existing `secrets.KUBECONFIG`, `secrets.CLOUDFLARE_TUNNEL_SERVICE_TOKEN_SECRET`, `vars.HOST`, `vars.CLOUDFLARE_TUNNEL_SERVICE_TOKEN_ID`. DNS is handled by the terraform change in this PR — no manual step.)

The matching **plaintext** passwords do **not** go here — the `ha` password goes into Home Assistant, and the `ci` password into the addon repo's CI secret. Those get wired up in the follow-up PRs (HA automation + the release workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
